### PR TITLE
Jonoshea dev

### DIFF
--- a/web/app/plugins/pobl-tech-blocks/blocks/src/pobl-tech-accordion-block/block.json
+++ b/web/app/plugins/pobl-tech-blocks/blocks/src/pobl-tech-accordion-block/block.json
@@ -22,6 +22,10 @@
 		"accordionID": {
 			"type": "string",
 			"default": ""
+		},
+		"accordionHeading": {
+			"type": "string",
+			"default": ""
 		}
 	}
 }

--- a/web/app/plugins/pobl-tech-blocks/blocks/src/pobl-tech-accordion-block/edit.js
+++ b/web/app/plugins/pobl-tech-blocks/blocks/src/pobl-tech-accordion-block/edit.js
@@ -38,23 +38,24 @@ import metadata from './block.json';
 export default function Edit( { attributes, setAttributes, clientId } ) {
 	const { getBlockOrder } = useSelect( ( select ) => select( 'core/block-editor' ), [] );
 	const { updateBlockAttributes, moveBlockToPosition } = useDispatch( 'core/block-editor' );
+	const { accordionID, accordionHeading } = attributes;
 
 	const isSelected = useSelect( ( select ) => {
         const { getSelectedBlockClientId } = select( 'core/block-editor' );
         return getSelectedBlockClientId() === clientId;
     }, [ clientId ] );
 
-	// If attributes.accordionID is undefined, set it
+	// If accordionID is undefined, set it
 	useEffect(() => {
-		if (!attributes.accordionID) {
+		if (!accordionID) {
 			setAttributes({ accordionID: 'pobl-tech-accordion-block-' + Math.floor(Math.random() * 100000) });
 		}
 
 		const innerBlockClientIds = getBlockOrder(clientId);
 		//const lastInnerBlockClientId = innerBlockClientIds[innerBlockClientIds.length - 1];
-		//updateBlockAttributes(lastInnerBlockClientId, { parentID: attributes.accordionID });
+		//updateBlockAttributes(lastInnerBlockClientId, { parentID: accordionID });
 		innerBlockClientIds.forEach( blockId => {
-			updateBlockAttributes( blockId, { parentID: attributes.accordionID } );
+			updateBlockAttributes( blockId, { parentID: accordionID } );
 		});
 	});
 
@@ -65,22 +66,32 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					<Disabled>
 						<TextControl
 							label={ __( 'Accordion ID', 'pobl-tech-accordion-block' ) }
-							value={ attributes.accordionID }
+							value={ accordionID }
 						/>
 					</Disabled>
+					<TextControl
+						label={ __( 'Accordion Heading', 'pobl-tech-accordion-block' ) }
+						value={ accordionHeading }
+						onChange={ ( value ) => setAttributes( { accordionHeading: value } ) }
+					/>
 				</PanelBody>
 			</InspectorControls>
 			<div className="accordion accordion-flush p-2">
+				{
+					accordionHeading !== '' && (
+						<h2>{ accordionHeading }</h2>
+					)
+				}
 				<InnerBlocks
 					allowedBlocks={ metadata.allowedBlocks }
 					template={ [
-						[ 'create-block/pobl-tech-accordion-item-block', { heading: 'Accordion Item Heading', body: 'Accordion item body', parentID: attributes.accordionID } ],
+						[ 'create-block/pobl-tech-accordion-item-block', { heading: 'Accordion Item Heading', body: 'Accordion item body', parentID: accordionID } ],
 					] }
 					onMove={ ( fromClientId, toClientId, indexToMove ) => {
 						moveBlockToPosition( fromClientId, toClientId, indexToMove );
 						const blockOrder = getBlockOrder( toClientId );
 						blockOrder.forEach( blockId => {
-							updateBlockAttributes( blockId, { parentID: attributes.accordionID } );
+							updateBlockAttributes( blockId, { parentID: accordionID } );
 						});
 					} }
 				/>

--- a/web/app/plugins/pobl-tech-blocks/blocks/src/pobl-tech-accordion-block/render.php
+++ b/web/app/plugins/pobl-tech-blocks/blocks/src/pobl-tech-accordion-block/render.php
@@ -3,8 +3,29 @@
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 ?>
-<div class="break-out-of-containers">
-	<div class="accordion accordion-flush <?php echo ($attributes['className'] ?? ''); ?>" id="<?php echo $attributes['accordionID']; ?>">
-		<?php echo $content; ?>
+<div class="break-out-of-containers pb-5">
+	<div class="w-100 bg-blue pt-md-5 pb-md-5">
+		<div class="container py-5 px-md-4 px-xl-5">
+			<div class="row justify-content-center">
+				<div class="col-12 col-md-10 col-lg-8">
+					<?php
+						if(!empty($attributes['accordionHeading'])) :
+					?>
+					<div class="row">
+						<div class="col-12">
+							<h2 class="text-white mb-5"><?php echo $attributes['accordionHeading']; ?></h2>
+						</div>
+					</div>
+					<?php endif; ?>
+					<div class="row">
+						<div class="col-12">
+							<div class="accordion accordion-flush <?php echo ($attributes['className'] ?? ''); ?>" id="<?php echo $attributes['accordionID']; ?>">
+								<?php echo $content; ?>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
 </div>

--- a/web/app/themes/estyn/app/View/Composers/HomeComposer.php
+++ b/web/app/themes/estyn/app/View/Composers/HomeComposer.php
@@ -44,6 +44,18 @@ class HomeComposer extends Composer
                 ];
             }
         }
+
+        $faqs = get_field('home_faqs'); // ACF Repeater field, each with a question and answer
+        if(!empty($faqs)) {
+            $faqs = array_map(function($faq) {
+                return [
+                    'question' => $faq['question'],
+                    'answer' => $faq['answer']
+                ];
+            }, $faqs);
+
+            $homeData['faqs'] = $faqs;
+        }
         
         return $homeData;
     }

--- a/web/app/themes/estyn/app/View/Composers/SearchComposer.php
+++ b/web/app/themes/estyn/app/View/Composers/SearchComposer.php
@@ -27,6 +27,8 @@ class SearchComposer extends Composer
         $sectors = get_terms([
             'taxonomy' => 'sector',
             'hide_empty' => false,
+            'orderby' => 'count',
+            'order' => 'DESC'
         ]);
 
         return $sectors;

--- a/web/app/themes/estyn/app/View/Composers/SectorsInArcContainerComposer.php
+++ b/web/app/themes/estyn/app/View/Composers/SectorsInArcContainerComposer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\View\Composers;
+
+use Roots\Acorn\View\Composer;
+
+class SectorsInArcContainerComposer extends Composer
+{
+    protected static $views = [
+        'partials.sectors-inside-full-width-arc-container'
+    ];
+
+    public function with()
+    {
+        return [
+            'sectors' => $this->sectors(),
+            'elemUniqueID' => uniqid()
+        ];
+    }
+
+    public function sectors()
+    {
+        $sectors = get_terms([
+            'taxonomy' => 'sector',
+            'hide_empty' => false,
+        ]);
+
+        // Format them as an array of items, each being an array with 'title' and 'linkURL' keys
+        $sectors = array_map(function($sector) {
+            return [
+                'title' => $sector->name,
+                'linkURL' => get_term_link($sector)
+            ];
+        }, $sectors);
+
+        return $sectors;
+    }
+}

--- a/web/app/themes/estyn/app/View/Composers/SectorsInArcContainerComposer.php
+++ b/web/app/themes/estyn/app/View/Composers/SectorsInArcContainerComposer.php
@@ -23,6 +23,8 @@ class SectorsInArcContainerComposer extends Composer
         $sectors = get_terms([
             'taxonomy' => 'sector',
             'hide_empty' => false,
+            'orderby' => 'count',
+            'order' => 'DESC'
         ]);
 
         // Format them as an array of items, each being an array with 'title' and 'linkURL' keys

--- a/web/app/themes/estyn/app/setup.php
+++ b/web/app/themes/estyn/app/setup.php
@@ -1071,7 +1071,7 @@ function estyn_resources_search(\WP_REST_Request $request) {
     // 'Similar Settings To Mine' filters
     $postsToRemove = [];
     
-    if( ((!empty($params['numLearners'])) && ($params['numLearners'] != 'any')) || ((!empty($params['languageMedium'])) && $params['languageMedium'] != 'any' ) || ((!empty($params['proximity'])) && $params['proximity'] != 'any' ) || ((!empty($params['ageRange'])) && $params['ageRange'] != 'any' ) ) {
+    if( ((!empty($params['numLearners'])) && ($params['numLearners'] != 'any')) || ((!empty($params['languageMedium'])) && $params['languageMedium'] != 'any' ) || ((!empty($params['proximity'])) && $params['proximity'] != 'any' && (!empty(trim($params['proximityPostcode'])))) || ((!empty($params['ageRange'])) && $params['ageRange'] != 'any' ) ) {
         // We need to get all the estyn_eduprovider posts that are
         // assigned to this post and check if any of them match the number of learners.
         // If they do, then we include this post in the results, otherwise we skip it.

--- a/web/app/themes/estyn/app/setup.php
+++ b/web/app/themes/estyn/app/setup.php
@@ -881,6 +881,16 @@ function estyn_resources_search(\WP_REST_Request $request) {
                 ],
             ];
         }
+    } elseif(isset($params['yearFrom']) && isset($params['yearTo'])) {
+        if(is_numeric($params['yearFrom']) && is_numeric($params['yearTo'])) {
+            $args['date_query'] = [
+                [
+                    'after' => $params['yearFrom'] . '-01-01',
+                    'before' => $params['yearTo'] . '-12-31',
+                    'inclusive' => true,
+                ],
+            ];
+        }
     }
 
     if(isset($params['searchText']) && !empty($params['searchText'])) {

--- a/web/app/themes/estyn/resources/styles/app.scss
+++ b/web/app/themes/estyn/resources/styles/app.scss
@@ -1203,6 +1203,15 @@ header {
     margin-bottom: 1.8rem;
 }
 
+.listArc {
+    margin-top: -71px;
+    z-index: -1;
+
+    svg {
+        width: 100%;
+    }
+}
+
 
 .homeProviderCol {
     border-right: 1px solid #6AA2C8;

--- a/web/app/themes/estyn/resources/styles/app.scss
+++ b/web/app/themes/estyn/resources/styles/app.scss
@@ -298,6 +298,13 @@ pre {
     }
 }
 
+.form-check-input {
+    width: 1.05em;
+    height: 1.05em;
+
+    border: $border-width solid #BADAFF;
+}
+
 
 /** TYPOGRAPHY **/
 

--- a/web/app/themes/estyn/resources/styles/app.scss
+++ b/web/app/themes/estyn/resources/styles/app.scss
@@ -71,6 +71,12 @@ $navbar-toggler-padding-x: 0;
 $navbar-brand-margin-end: var(--navbar-brand-margin-right);
 $navbar-toggler-focus-width: 0;
 
+$btn-close-color: $estyn-blue;
+$btn-close-width: 0.5em;
+$btn-close-opacity: 1;
+
+$modal-header-padding: 1.5rem 1rem 1rem 1rem;
+
 
 @import 'bootstrap/scss/bootstrap';
 @import 'common/fonts';
@@ -1275,6 +1281,43 @@ header {
             @include media-breakpoint-down(md) {
                 border-top-left-radius: 6px;
                 border-bottom-left-radius: 6px;
+            }
+        }
+
+        .estyn-search-results-modal {
+            h2, p, .form-label {
+                color: $body-color;
+            }
+    
+            .form-control {
+                background-color: $estyn-lightblue;
+                padding: 0.25rem 0.75rem;
+                color: $body-color;
+                font-size: 16px;
+            }
+    
+            .btn, .btn-secondary {
+                font-size: 16px;
+                color: $estyn-white;
+                background-color: $estyn-blue;
+                padding: 0.5rem 0.8rem;
+            }
+
+            .modal-header {
+                border-bottom: none;
+            }
+
+            .modal-body {
+                .list-group-item {
+                    border: none;
+                    padding: 0;
+                    margin-bottom: 0.75rem;
+
+                    a {
+                        text-decoration: none;
+                        color: $estyn-blue;
+                    }
+                }
             }
         }
     }

--- a/web/app/themes/estyn/resources/styles/app.scss
+++ b/web/app/themes/estyn/resources/styles/app.scss
@@ -254,6 +254,17 @@ pre {
     }
 }
 
+.tag-search-container {
+    .form-check {
+        
+    }
+    .tag-list {
+        max-height: 250px;
+        overflow-y: auto;
+    }
+}
+
+
 /** TYPOGRAPHY **/
 
 p, li {

--- a/web/app/themes/estyn/resources/styles/app.scss
+++ b/web/app/themes/estyn/resources/styles/app.scss
@@ -174,7 +174,54 @@ body {
 .bg-estyn-blue {
     background-color: $estyn-blue;
 }
-.bg-blue {background-color: $estyn-blue}
+.bg-blue {
+    background-color: $estyn-blue;
+
+    .accordion-item {
+        background: transparent;
+        color: $estyn-white;
+    }
+
+    .accordion-button {
+        background: transparent;
+        color: $estyn-white;
+
+        padding-left: 0;
+        padding-right: 0;
+
+        font-size: 24px;
+        font-family: "museo", serif;
+        font-weight: 500;
+        font-style: normal;
+
+        &::after {
+            // Ridiculously complex way to set the arrow colour to white
+            filter: invert(100%) sepia(0%) saturate(0%) hue-rotate(360deg) brightness(100%) contrast(100%);
+        }
+
+        &:focus {
+            outline: none;
+        }
+    }
+
+    .accordion-body {
+        padding-left: 0;
+        padding-right: 0;
+
+        p, li {
+            font-size: 19px;
+            font-family: "Source Sans 3", sans-serif;
+            font-style: normal;
+            line-height: 26px;
+        }
+
+        p, li, a, h2, h3, h4, h5 {
+            color: $estyn-lightblue;
+        }
+    }
+}
+
+
 .bg-darkblue {background-color: $estyn-darkblue}
 .bg-lightblue {background-color: $estyn-lightblue}
 .bg-white {background-color:$estyn-white}

--- a/web/app/themes/estyn/resources/styles/app.scss
+++ b/web/app/themes/estyn/resources/styles/app.scss
@@ -1555,6 +1555,11 @@ p.sp-desc {
 .ctaMapLink {
     color: $estyn-white;
     font-size: 18px;
+
+    @include media-breakpoint-down(sm) {
+        font-size: 14px;
+    }
+
     line-height: 24px;
     font-family: "museo", serif;
     font-weight: 700;
@@ -1563,6 +1568,18 @@ p.sp-desc {
     &:hover {
         color: $estyn-white;
         background-color: rgba(255, 255, 255, 0.2);
+    }
+}
+
+.border-sm-bottom {
+    @include media-breakpoint-up(sm) {
+        border-bottom: $border-width solid $border-color;
+    }
+}
+
+.border-top-sm-0 {
+    @include media-breakpoint-up(sm) {
+        border-top: 0 !important;
     }
 }
 

--- a/web/app/themes/estyn/resources/styles/app.scss
+++ b/web/app/themes/estyn/resources/styles/app.scss
@@ -254,13 +254,41 @@ pre {
     }
 }
 
-.tag-search-container {
-    .form-check {
-        
+.tag-search-container, .searchFilter .tag-search-container {
+    .form-control {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
     }
     .tag-list {
-        max-height: 250px;
+        max-height: 173px;
         overflow-y: auto;
+
+        border-left: 1px solid $estyn-bluegrey;
+        border-right: 1px solid $estyn-bluegrey;
+        border-bottom: 1px solid $estyn-bluegrey;
+
+        border-bottom-left-radius: $border-radius-form;
+        border-bottom-right-radius: $border-radius-form;
+
+        .form-check {
+            padding: 0.45rem 0.675rem;
+            margin-bottom: 0;
+
+            display: flex;
+
+            &:nth-child(odd) {
+                background-color: #ECF6FE;
+            }
+            &:nth-child(even) {
+                background-color: $estyn-lightblue;
+            }
+
+            .form-check-input {
+                float: none;
+                margin-left: 0;
+                margin-right: 0.55rem;
+            }
+        }
     }
 }
 

--- a/web/app/themes/estyn/resources/styles/app.scss
+++ b/web/app/themes/estyn/resources/styles/app.scss
@@ -1152,7 +1152,8 @@ header {
     }    
 
     .form-control {
-        color: $estyn-darkblue;
+        color: $estyn-white;
+        font-size: 20px;
         background-color: $estyn-anotherlightblue; /* #7EB1D6;*/
         background-clip: padding-box;
         border: none;/* 1px solid $estyn-lightbluegrey; */
@@ -1181,7 +1182,7 @@ header {
             }
         }
 
-        input[type="text"] {
+        input[type="text"], &.input-group > input[type="text"]:not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
             border-top-left-radius: 10px;
             border-bottom-left-radius: 10px;
 
@@ -1192,6 +1193,7 @@ header {
         }
     }
 }
+
 
 .insideIntroArc, .homeIntroArc {margin-top: -71px;} /*Make this the same as the height of the SVG*/
 .insideIntroArc svg, .homeIntroArc svg {width:100%;}

--- a/web/app/themes/estyn/resources/views/components/accordion-in-full-width-container.blade.php
+++ b/web/app/themes/estyn/resources/views/components/accordion-in-full-width-container.blade.php
@@ -1,0 +1,35 @@
+<div class="w-100 bg-blue pt-md-5 pb-md-5">
+    <div class="container py-5 px-md-4 px-xl-5">
+        <div class="row justify-content-center">
+            <div class="col-12 col-md-10 col-lg-8">
+                @if(!empty($heading))
+                    <div class="row">
+                        <div class="col-12">
+                            <h2 class="text-white mb-5">{{ $heading }}</h2>
+                        </div>
+                    </div>
+                @endif
+                <div class="row">
+                    <div class="col-12">
+                        <div class="accordion accordion-flush" id="{{ $id }}">
+                            @foreach($items as $item)
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="{{ $id }}-heading-{{ $loop->iteration }}">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ $id }}-collapse-{{ $loop->iteration }}" aria-expanded="false" aria-controls="{{ $id }}-collapse-{{ $loop->iteration }}">
+                                            {{ $item['question'] }}
+                                        </button>
+                                    </h2>
+                                    <div id="{{ $id }}-collapse-{{ $loop->iteration }}" class="accordion-collapse collapse" aria-labelledby="{{ $id }}-heading-{{ $loop->iteration }}" data-bs-parent="#{{ $id }}">
+                                        <div class="accordion-body">
+                                            {!! $item['answer'] !!}
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
+++ b/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
@@ -53,8 +53,8 @@
                                             </div> {{-- Close the previous row --}}
                                             <div class="row">
                                         @endif
-                                                <div class="col-12 col-sm-6 mb-4">
-                                                    <span class="pb-2 border-bottom d-block">
+                                                <div class="col-12 col-sm-6 {{ $loop->iteration != 12 ? 'mb-3 mb-sm-4' : 'mb-2 mb-sm-4' }}">
+                                                    <span class="{{ $loop->iteration != 12 ? 'pb-2 border-bottom' : 'pb-sm-2 border-sm-bottom' }} d-block">
                                                         <a href="{{ $listItem['linkURL'] }}" class="ctaMapLink text-decoration-none">{!! $listItem['title'] !!}</a>
                                                     </span>
                                                 </div>
@@ -86,8 +86,8 @@
                                             </div> {{-- Close the previous row --}}
                                             <div class="row">
                                         @endif
-                                                <div class="col-12 col-sm-6 mb-4">
-                                                    <span class="pb-2 border-bottom d-block">
+                                                <div class="col-12 col-sm-6 mb-3 mb-sm-4">
+                                                    <span class="pb-2 {{ $loop->iteration == 13 ? 'pt-3 pt-sm-0 border-top border-top-sm-0' : '' }} {{ !$loop->last ? 'border-bottom' : 'border-sm-bottom' }} d-block">
                                                         <a href="{{ $listItem['linkURL'] }}" class="ctaMapLink text-decoration-none">{!! $listItem['title'] !!}</a>
                                                     </span>
                                                 </div>
@@ -98,7 +98,7 @@
                                 </div>
                             </div>
                             <div class="row">
-                                <div class="col-12 d-flex justify-content-center mt-4">
+                                <div class="col-12 d-flex justify-content-center mt-5">
                                     <a id="{{ $elemUniqueID }}-toggle-show-more" class="btn btn-outline-primary px-5 text-white bg-transparent-even-when-active border-white rounded-5 cta-toggle-more-less" data-bs-toggle="collapse" href="#{{ $elemUniqueID }}-collapseSectors" role="button" aria-expanded="false" aria-controls="{{ $elemUniqueID }}-collapseSectors">{{ __('See more') }}</a>
                                 </div>
                             </div>

--- a/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
+++ b/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
@@ -20,7 +20,7 @@
     <div class="w-100 bg-blue pt-md-5 pb-md-5">
         <div class="container py-5 px-md-4 px-xl-5">
             <div class="row justify-content-center">
-                <div class="col-12 col-md-10">
+                <div class="col-12 col-md-10 col-lg-8">
                     @if(!empty($heading))
                         <div class="row">
                             <div class="col-12">

--- a/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
+++ b/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
@@ -119,10 +119,10 @@
             const elemCollapseSectors = document.getElementById("{{ $elemUniqueID }}-collapseSectors");
 
             elemCollapseSectors.addEventListener('hidden.bs.collapse', event => {
-                elemToggleShowMore.innerHTML = "{{ __('Show more', 'sage') }}";
+                elemToggleShowMore.innerHTML = "{{ __('See more', 'sage') }}";
             });
             elemCollapseSectors.addEventListener('shown.bs.collapse', event => {
-                elemToggleShowMore.innerHTML = "{{ __('Show less', 'sage') }}";
+                elemToggleShowMore.innerHTML = "{{ __('See less', 'sage') }}";
             });
         });
     </script>

--- a/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
+++ b/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
@@ -18,7 +18,7 @@
     </div>
     {{--<div class="ctaArcMapBGFiller position-absolute w-100 bg-blue"></div>--}}
     <div class="w-100 bg-blue pt-md-5 pb-md-5">
-        <div class="container py-5 px-md-4 px-xl-5">
+        <div class="container pt-md-5 pb-5 px-md-4 px-xl-5">
             <div class="row justify-content-center">
                 <div class="col-12 col-md-10 col-lg-8">
                     @if(!empty($heading))

--- a/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
+++ b/web/app/themes/estyn/resources/views/components/list-inside-full-width-arc-container.blade.php
@@ -1,0 +1,129 @@
+<div class="mt-5 pt-5 mb-md-5 pb-md-5">
+<section class="cta my-5 position-relative" id="{{ $elemUniqueID }}">
+    <!-- Arc for larger screens -->
+    <div class="listArc position-absolute w-100 d-none d-md-block">
+        <svg width="1600" height="364" viewBox="0 0 1600 364" preserveAspectRatio="none">
+        <path d=
+        "M0,54.7C0,54.7,392,0,792,0s808,54.7,808,54.7v310H0V54.7z" 
+        fill="#2A7AB0" />
+        </svg>
+    </div>
+    <!-- Arc for smaller screens -->
+    <div class="listArc position-absolute w-100 d-block d-md-none">
+        <svg width="1600" height="182" viewBox="0 0 1600 364" preserveAspectRatio="none">
+        <path d=
+        "M0,54.7C0,54.7,392,0,792,0s808,54.7,808,54.7v310H0V54.7z" 
+        fill="#2A7AB0" />
+        </svg>
+    </div>
+    {{--<div class="ctaArcMapBGFiller position-absolute w-100 bg-blue"></div>--}}
+    <div class="w-100 bg-blue pt-md-5 pb-md-5">
+        <div class="container py-5 px-md-4 px-xl-5">
+            <div class="row justify-content-center">
+                <div class="col-12 col-md-10">
+                    @if(!empty($heading))
+                        <div class="row">
+                            <div class="col-12">
+                                <h2 class="text-white mb-5">{{ $heading }}</h2>
+                            </div>
+                        </div>
+                    @endif
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="row">
+                                <div class="col-12">
+                                    @foreach($listItems as $listItem)
+                                        @php
+                                            // We want the last word of the list item name to be contained within a span (with class no-wrap)
+                                            // and next to it we want the arrow icon
+                                            $listItemTitleParts = explode(' ', $listItem['title']);
+                                            $listItemTitlePartsCount = count($listItemTitleParts);
+                                            $listItemTitleLastWord = $listItemTitleParts[$listItemTitlePartsCount - 1];
+                                            $listItemTitleParts[$listItemTitlePartsCount - 1] = '<span class="text-nowrap text-decoration-none">' . $listItemTitleLastWord . ' <i class="fa-sharp fa-regular fa-arrow-up-right text-decoration-none"></i></span>';
+                                            $listItem['title'] = implode(' ', $listItemTitleParts);
+                                        @endphp
+                                        @if($loop->iteration > 12) {{-- Only show the first 12 items --}}
+                                            </div> {{-- Close the previous row --}}
+                                            @break
+                                        @endif
+                                        @if($loop->iteration == 1)
+                                            <div class="row">
+                                        {{-- If $loop->iteration is odd, start a new row --}}
+                                        @elseif($loop->iteration % 2 == 1)
+                                            </div> {{-- Close the previous row --}}
+                                            <div class="row">
+                                        @endif
+                                                <div class="col-12 col-sm-6 mb-4">
+                                                    <span class="pb-2 border-bottom d-block">
+                                                        <a href="{{ $listItem['linkURL'] }}" class="ctaMapLink text-decoration-none">{!! $listItem['title'] !!}</a>
+                                                    </span>
+                                                </div>
+                                        @if($loop->last)
+                                            </div> {{-- Close the last row --}}
+                                        @endif
+                                    @endforeach
+                                </div>
+                            </div>
+                            <div class="row collapse" id="{{ $elemUniqueID }}-collapseSectors">
+                                <div class="col-12">
+                                    @foreach($listItems as $listItem)
+                                        @php
+                                            // We want the last word of the list item name to be contained within a span (with class no-wrap)
+                                            // and next to it we want the arrow icon
+                                            $listItemTitleParts = explode(' ', $listItem['title']);
+                                            $listItemTitlePartsCount = count($listItemTitleParts);
+                                            $listItemTitleLastWord = $listItemTitleParts[$listItemTitlePartsCount - 1];
+                                            $listItemTitleParts[$listItemTitlePartsCount - 1] = '<span class="text-nowrap text-decoration-none">' . $listItemTitleLastWord . ' <i class="fa-sharp fa-regular fa-arrow-up-right text-decoration-none"></i></span>';
+                                            $listItem['title'] = implode(' ', $listItemTitleParts);
+                                        @endphp
+                                        @if($loop->iteration < 13) {{-- Only show the 13th item onwards --}}
+                                            @continue
+                                        @endif
+                                        @if($loop->iteration == 13)
+                                            <div class="row">
+                                        {{-- If $loop->iteration is odd, start a new row --}}
+                                        @elseif($loop->iteration % 2 == 1)
+                                            </div> {{-- Close the previous row --}}
+                                            <div class="row">
+                                        @endif
+                                                <div class="col-12 col-sm-6 mb-4">
+                                                    <span class="pb-2 border-bottom d-block">
+                                                        <a href="{{ $listItem['linkURL'] }}" class="ctaMapLink text-decoration-none">{!! $listItem['title'] !!}</a>
+                                                    </span>
+                                                </div>
+                                        @if($loop->last)
+                                            </div> {{-- Close the last row --}}
+                                        @endif
+                                    @endforeach
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-12 d-flex justify-content-center mt-4">
+                                    <a id="{{ $elemUniqueID }}-toggle-show-more" class="btn btn-outline-primary px-5 text-white bg-transparent-even-when-active border-white rounded-5 cta-toggle-more-less" data-bs-toggle="collapse" href="#{{ $elemUniqueID }}-collapseSectors" role="button" aria-expanded="false" aria-controls="{{ $elemUniqueID }}-collapseSectors">{{ __('See more') }}</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+</div>
+@push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', (event) => {
+            //console.log('Initialising list-inside-full-width-arc-container with ID {{ $elemUniqueID }}');
+            const elemUniqueID = "{{ $elemUniqueID }}";
+            const elemToggleShowMore = document.getElementById("{{ $elemUniqueID }}-toggle-show-more");
+            const elemCollapseSectors = document.getElementById("{{ $elemUniqueID }}-collapseSectors");
+
+            elemCollapseSectors.addEventListener('hidden.bs.collapse', event => {
+                elemToggleShowMore.innerHTML = "{{ __('Show more', 'sage') }}";
+            });
+            elemCollapseSectors.addEventListener('shown.bs.collapse', event => {
+                elemToggleShowMore.innerHTML = "{{ __('Show less', 'sage') }}";
+            });
+        });
+    </script>
+@endpush

--- a/web/app/themes/estyn/resources/views/layouts/app.blade.php
+++ b/web/app/themes/estyn/resources/views/layouts/app.blade.php
@@ -34,6 +34,8 @@
         'sectors' => isset($sectors) ? $sectors : get_terms([
             'taxonomy' => 'sector',
             'hide_empty' => false,
+            'orderby' => 'count',
+            'order' => 'DESC'
           ])
       ])
 

--- a/web/app/themes/estyn/resources/views/partials/cta.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/cta.blade.php
@@ -151,6 +151,8 @@
 									$sectors = isset($sectors) ? $sectors : get_terms([
 										'taxonomy' => 'sector',
 										'hide_empty' => false,
+										'orderby' => 'count',
+										'order' => 'DESC'
 									]);
 								@endphp
 								@foreach($sectors as $sector)

--- a/web/app/themes/estyn/resources/views/partials/home-faqs.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/home-faqs.blade.php
@@ -1,0 +1,1 @@
+@include('components.accordion-in-full-width-container', ['items' => $faqs, 'heading' => __('FAQs', 'sage'), 'id' => 'home-faqs'])

--- a/web/app/themes/estyn/resources/views/partials/search-page.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/search-page.blade.php
@@ -423,44 +423,33 @@
                         <label for="proximityPostcode" class="form-label">{{ __('Postcode', 'sage') }}:</label>
                         <input type="text" class="form-control proximityPostcode" id="proximityPostcode" name="proximityPostcode" placeholder="{{ __('Enter a postcode', 'sage') }}">
                       </div>
-                      <div class="form-check">
-                        <input class="form-check-input" type="radio" name="proximity" value="any" id="flexCheckProximity-any" checked>
-                        <label class="form-check-label" for="flexCheckProximity-any">
-                          {{ __('Any proximity', 'sage') }}
-                        </label>
+
+                      <div class="form-input mb-2">
+                        <label for="proximityRange" class="form-label">{{ __('Search radius', 'sage') }}:</label>
+                        <select class="form-select proximity-range" name="proximity" id="proximityRange">
+                          <option value="0-0.1">{{ __('This area only', 'sage') }}</option>
+                          <option value="0-0.25">{{ __('Within 1/4 mile', 'sage') }}</option>
+                          <option value="0-0.5">{{ __('Within 1/2 mile', 'sage') }}</option>
+                          <option value="0-1">{{ __('Within 1 mile', 'sage') }}</option>
+                          <option value="0-3">{{ __('Within 3 miles', 'sage') }}</option>
+                          <option value="0-5">{{ __('Within 5 miles', 'sage') }}</option>
+                          <option value="0-10">{{ __('Within 10 miles', 'sage') }}</option>
+                          <option value="0-15">{{ __('Within 15 miles', 'sage') }}</option>
+                          <option value="0-20">{{ __('Within 20 miles', 'sage') }}</option>
+                          <option value="0-30">{{ __('Within 30 miles', 'sage') }}</option>
+                          <option value="0-40">{{ __('Within 40 miles', 'sage') }}</option>
+                        </select>
                       </div>
-                      {{-- '0-10', '0-20', '0-30', '0-40', ... , '0-250' --}}
-                      @for($i = 10; $i < 250; $i += 10)
+     
+                      {{--@for($i = 10; $i < 250; $i += 10)
                         <div class="form-check">
                           <input class="form-check-input proximity-range"  type="radio" name="proximity" value="0-{{ $i }}" id="flexCheckProximity-0-{{ $i }}">
                           <label class="form-check-label" for="flexCheckProximity-0-{{ $i }}">
                             0-{{ $i }} {{ __('miles', 'sage') }}
                           </label>
                         </div>
-                      @endfor
-
-                      {{--@for($i = 0; $i < 50; $i += 10)
-                        <div class="form-check">
-                          <input class="form-check-input" type="radio" name="proximity" value="{{ $i }}-{{ $i + 10 }}" id="flexCheckProximity-{{ $i }}-{{ $i + 10 }}">
-                          <label class="form-check-label" for="flexCheckProximity-{{ $i }}-{{ $i + 10 }}">
-                            {{ $i }}-{{ $i + 10 }} {{ __('miles', 'sage') }}
-                          </label>
-                        </div>
-                      @endfor
-                      @for($i = 50; $i <= 200; $i += 50)
-                        <div class="form-check">
-                          <input class="form-check-input" type="radio" name="proximity" value="{{ $i }}-{{ $i + 50 }}" id="flexCheckProximity-{{ $i }}-{{ $i + 50 }}">
-                          <label class="form-check-label" for="flexCheckProximity-{{ $i }}-{{ $i + 50 }}">
-                            {{ $i }}-{{ $i + 50 }} {{ __('miles', 'sage') }}
-                          </label>
-                        </div>
                       @endfor--}}
-                      <div class="form-check">
-                        <input class="form-check-input" type="radio" name="proximity" value="250-plus" id="flexCheckProximity-250-plus">
-                        <label class="form-check-label" for="flexCheckProximity-250-plus">
-                          {{ __('250+ miles', 'sage') }}
-                        </label>
-                      </div>
+
                     </div>
                   </div>
                 </div>
@@ -1118,7 +1107,7 @@
 			$(document).ready(function() {
 				hideSearchResultsLoadingIndicator();
 
-				$(".search-filters input:not([type='text']), #yearFrom, #yearTo").on("change", function() {
+				$(".search-filters input:not([type='text']), .search-filters select").on("change", function() {
           if($(this).hasClass('proximity-range') && $("#proximityPostcode").val().trim() == "") {
             // Add Bootstrap error class/es to the postcode input
             $("#proximityPostcode").addClass('is-invalid');
@@ -1168,7 +1157,8 @@
           const self = $(this); // Preserve the context
 
           postcodeBoxTypingTimer = setTimeout(() => { // Use arrow function
-            if($("#flexCheckProximity-any").is(":checked") || self.val().trim() === "" || self.val().trim().length < 3) {
+            //if($("#flexCheckProximity-any").is(":checked") || self.val().trim() === "" || self.val().trim().length < 3) {
+            if(self.val().trim() === "" || self.val().trim().length < 3) {
               return;
             }
             applyFilters();
@@ -1338,7 +1328,8 @@
           //numLearners: $("#flush-collapseLearners input:checked").val(),
           languageMedium: $("#flush-collapseLanguageMedium input:checked").val(),
           //ageRange: $("#flush-collapseAgeRange input:checked").val(),
-          proximity: $("#flush-collapseProximity input:checked").val(),
+          //proximity: $("#flush-collapseProximity input:checked").val(),
+          proximity: $("#proximityRange").val(),
           proximityPostcode: $("#flush-collapseProximity input[type='text']").val().trim()
         };
       }

--- a/web/app/themes/estyn/resources/views/partials/search-page.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/search-page.blade.php
@@ -206,11 +206,11 @@
                     <div class="accordion-body">
                       <div class="tag-search-container">
                         <div class="form-group">
-                            <input type="text" class="form-control mb-3" id="searchTags" placeholder="{{ __('Search tags', 'sage') }}">
+                            <input type="text" class="form-control" id="searchTags" placeholder="{{ __('Search tags', 'sage') }}">
                             <div id="tagList" class="tag-list">
                                 @foreach($tags as $tag)
                                     <div class="form-check">
-                                      <input class="form-check-input" type="checkbox" value="{{ $tag->slug }}" name="tags[]" {{ (!empty($_GET['tag'])) && (strtolower($_GET['tag']) == strtolower($tag->name)) ? 'checked' : '' }}>
+                                      <input class="form-check-input" type="checkbox" id="flexCheckTags-{{ $tag->slug }}" value="{{ $tag->slug }}" name="tags[]" {{ (!empty($_GET['tag'])) && (strtolower($_GET['tag']) == strtolower($tag->name)) ? 'checked' : '' }}>
                                       <label class="form-check-label" for="flexCheckTags-{{ $tag->slug }}">
                                           {{ $tag->name }}
                                       </label>

--- a/web/app/themes/estyn/resources/views/partials/search-page.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/search-page.blade.php
@@ -204,14 +204,29 @@
                   </h2>
                   <div id="flush-collapseThree" class="accordion-collapse collapse" aria-labelledby="flush-headingThree" data-bs-parent="#accordionFlushExample">
                     <div class="accordion-body">
-                      @foreach($tags as $tag)
+                      <div class="tag-search-container">
+                        <div class="form-group">
+                            <input type="text" class="form-control mb-3" id="searchTags" placeholder="{{ __('Search tags', 'sage') }}">
+                            <div id="tagList" class="tag-list">
+                                @foreach($tags as $tag)
+                                    <div class="form-check">
+                                      <input class="form-check-input" type="checkbox" value="{{ $tag->slug }}" name="tags[]" {{ (!empty($_GET['tag'])) && (strtolower($_GET['tag']) == strtolower($tag->name)) ? 'checked' : '' }}>
+                                      <label class="form-check-label" for="flexCheckTags-{{ $tag->slug }}">
+                                          {{ $tag->name }}
+                                      </label>
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                      </div>
+                      {{--@foreach($tags as $tag)
                         <div class="form-check">
                           <input class="form-check-input" type="checkbox" value="{{ $tag->slug }}" name="tags[]" {{ (!empty($_GET['tag'])) && (strtolower($_GET['tag']) == strtolower($tag->name)) ? 'checked' : '' }}>
                           <label class="form-check-label" for="flexCheckTags-{{ $tag->slug }}">
                             {{ $tag->name }}
                           </label>
                         </div>
-                      @endforeach
+                      @endforeach--}}
                     </div>
                   </div>
                 </div>
@@ -250,7 +265,25 @@
                       </h2>
                       <div id="flush-collapseFive" class="accordion-collapse collapse" aria-labelledby="flush-headingFive" data-bs-parent="#accordionFlushExample">
                         <div class="accordion-body">
-                          <div class="form-check">
+                          <div class="row">
+                            <div class="col">
+                              <label for="yearFrom">{{ __('From', 'sage') }}</label>
+                              <select class="form-control" name="yearFrom" id="yearFrom">
+                                @for ($i = 2005; $i <= intval(date('Y')); $i++)
+                                  <option value="{{ $i }}">{{ $i }}</option>
+                                @endfor
+                              </select>
+                            </div>
+                            <div class="col">
+                              <label for="yearTo">{{ __('To', 'sage') }}</label>
+                              <select class="form-control" name="yearTo" id="yearTo">
+                                @for ($i = 2005; $i <= intval(date('Y')); $i++)
+                                  <option value="{{ $i }}" {{ $i == intval(date('Y')) ? 'selected' : '' }}>{{ $i }}</option>
+                                @endfor
+                              </select>
+                            </div>
+                          </div>
+                          {{--<div class="form-check">
                             <input class="form-check-input" type="radio" name="year" id="flexCheckYearDefault" checked>
                             <label class="form-check-label" for="flexCheckYearDefault">
                               {{ __('Any year', 'sage') }}
@@ -263,7 +296,7 @@
                                 {{ $i }}
                               </label>
                             </div>
-                          @endfor
+                          @endfor--}}
                         </div>
                       </div>
                   </div>
@@ -1085,7 +1118,7 @@
 			$(document).ready(function() {
 				hideSearchResultsLoadingIndicator();
 
-				$(".search-filters input:not([type='text'])").on("change", function() {
+				$(".search-filters input:not([type='text']), #yearFrom, #yearTo").on("change", function() {
           if($(this).hasClass('proximity-range') && $("#proximityPostcode").val().trim() == "") {
             // Add Bootstrap error class/es to the postcode input
             $("#proximityPostcode").addClass('is-invalid');
@@ -1140,6 +1173,10 @@
             }
             applyFilters();
           }, postcodeBoxTypingInterval);
+        });
+
+        $("#searchTags").on("keyup", function(key) {
+          filterTags();
         });
 
         @if(!empty($searchArgs))
@@ -1217,7 +1254,9 @@
 				
 				return {
 					postType: postType,
-					year: $("#flush-collapseTwo input:checked").val(),
+          // year: $("#flush-collapseTwo input:checked").val(),
+					yearFrom: $("#yearFrom").val(),
+          yearTo: $("#yearTo").val(),
 					searchText: $("#search-box-container input[type='text']").val().trim(),
 					sort: sort
 				};
@@ -1293,7 +1332,9 @@
             return $(this).val();
           }).get(),
           improvementResourceType: $("#flush-collapseFour input:checked").val(),
-          year: $("#flush-collapseFive input:checked").val(),
+          // year: $("#flush-collapseTwo input:checked").val(),
+					yearFrom: $("#yearFrom").val(),
+          yearTo: $("#yearTo").val(),
           //numLearners: $("#flush-collapseLearners input:checked").val(),
           languageMedium: $("#flush-collapseLanguageMedium input:checked").val(),
           //ageRange: $("#flush-collapseAgeRange input:checked").val(),
@@ -1314,6 +1355,24 @@
 					opacity: 1
 				}, 250);
 			}
+
+      function filterTags() {
+          var input, filter, tagList, tags, label, i, txtValue;
+          input = document.getElementById('searchTags');
+          filter = input.value.toUpperCase();
+          tagList = document.getElementById("tagList");
+          tags = tagList.getElementsByClassName('form-check');
+
+          for (i = 0; i < tags.length; i++) {
+              label = tags[i].getElementsByTagName("label")[0];
+              txtValue = label.textContent || label.innerText;
+              if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                  tags[i].style.display = "";
+              } else {
+                  tags[i].style.display = "none";
+              }
+          }
+      }
 		})(jQuery);
 	</script>
 @endpush

--- a/web/app/themes/estyn/resources/views/partials/search-page.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/search-page.blade.php
@@ -268,7 +268,7 @@
                           <div class="row">
                             <div class="col">
                               <label for="yearFrom">{{ __('From', 'sage') }}</label>
-                              <select class="form-control" name="yearFrom" id="yearFrom">
+                              <select class="form-select" name="yearFrom" id="yearFrom">
                                 @for ($i = 2005; $i <= intval(date('Y')); $i++)
                                   <option value="{{ $i }}">{{ $i }}</option>
                                 @endfor
@@ -276,7 +276,7 @@
                             </div>
                             <div class="col">
                               <label for="yearTo">{{ __('To', 'sage') }}</label>
-                              <select class="form-control" name="yearTo" id="yearTo">
+                              <select class="form-select" name="yearTo" id="yearTo">
                                 @for ($i = 2005; $i <= intval(date('Y')); $i++)
                                   <option value="{{ $i }}" {{ $i == intval(date('Y')) ? 'selected' : '' }}>{{ $i }}</option>
                                 @endfor

--- a/web/app/themes/estyn/resources/views/partials/search-page.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/search-page.blade.php
@@ -77,7 +77,7 @@
 					<div class="col-12 col-md-11">
 
 						<div id="search-box-container" class="input-group mb-4">
-						  <input type="text" class="form-control" placeholder="" aria-label="Search filter" aria-describedby="searchFilter">
+						  <input type="text" class="form-control" placeholder="" aria-label="Search filter" aria-describedby="searchFilter" value="{{ !empty($_GET['search']) ? $_GET['search'] : '' }}">
 						  <button class="btn btn-primary" type="button" id="searchFilter"><i class="fa-sharp fa-solid fa-magnifying-glass"></i></button>
 						</div>
 
@@ -604,8 +604,8 @@
           ];
 
           // If there's a Wordpress search query in the URL then add it to the search args
-          if(isset($_GET['s'])) {
-            $searchArgs['s'] = trim($_GET['s']);
+          if(isset($_GET['search'])) {
+            $searchArgs['s'] = trim($_GET['search']);
           }
         } elseif($isImprovementResourcesSearch) {
           $searchArgs = [
@@ -617,8 +617,8 @@
           ];
 
           // If there's a Wordpress search query in the URL then add it to the search args
-          if(isset($_GET['s'])) {
-            $searchArgs['s'] = trim($_GET['s']);
+          if(isset($_GET['search'])) {
+            $searchArgs['s'] = trim($_GET['search']);
           }
 
           // Sectors
@@ -682,8 +682,8 @@
           ];
 
           // If there's a Wordpress search query in the URL then add it to the search args
-          if(isset($_GET['s'])) {
-            $searchArgs['s'] = trim($_GET['s']);
+          if(isset($_GET['search'])) {
+            $searchArgs['s'] = trim($_GET['search']);
           }
 
           // Sector
@@ -726,8 +726,8 @@
           ];
 
           // If there's a Wordpress search query in the URL then add it to the search args
-          if(isset($_GET['s'])) {
-            $searchArgs['s'] = trim($_GET['s']);
+          if(isset($_GET['search'])) {
+            $searchArgs['s'] = trim($_GET['search']);
           }
 
           // Sector
@@ -771,8 +771,8 @@
           ];
 
           // If there's a Wordpress search query in the URL then add it to the search args
-          if(isset($_GET['s'])) {
-            $searchArgs['s'] = trim($_GET['s']);
+          if(isset($_GET['search'])) {
+            $searchArgs['s'] = trim($_GET['search']);
           }
 
           // Sector

--- a/web/app/themes/estyn/resources/views/partials/search-page.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/search-page.blade.php
@@ -86,7 +86,7 @@
 
             <div class="search-filters collapse d-md-block pb-5" id="search-filters">
               <h3>{{ __('Filters', 'sage') }}</h3>
-              <div class="accordion accordion-flush pb-5 pb-sm-0" id="accordionFlushExample">
+              <div class="accordion accordion-flush pb-3 pb-sm-0" id="accordionFlushExample">
                 @if(isset($isNewsAndBlog) && $isNewsAndBlog)
                   <div class="accordion-item">
                       <h2 class="accordion-header" id="flush-headingOne">
@@ -591,6 +591,10 @@
               </div>
             
             @endif
+            {{-- Reset filters button --}}
+              <div class="mt-4">
+                <button type="button" class="btn btn-outline-primary reset-filters-button" id="resetFilters">{{ __('Reset filters', 'sage') }}</button>
+              </div>
             </div>
 					</div>
 				</div>
@@ -1106,6 +1110,33 @@
 
 			$(document).ready(function() {
 				hideSearchResultsLoadingIndicator();
+
+        $(".reset-filters-button").on("click", function() {
+          $(".search-filters input, .search-filters select").each(function() {
+            if($(this).attr('type') == 'checkbox') {
+              $(this).prop('checked', false);
+            } else if($(this).attr('type') == 'radio') {
+              $(this).prop('checked', false);
+            }
+            else if($(this).attr('id') == 'yearFrom') {
+              $(this).val($(this).find('option:first').val());
+            } else if($(this).attr('id') == 'yearTo') {
+              $(this).val("{{ date('Y') }}");
+            } else if($(this).hasClass('proximity-range')) {
+              // Set the value to the first option
+              $(this).val($(this).find('option:first').val());
+            }
+             else {
+              $(this).val('');
+            }
+          });
+
+          $("#search-box-container input[type='text']").val('');
+          $("#searchTags").val('');
+
+          currentPage = 1;
+          applyFilters();
+        });
 
 				$(".search-filters input:not([type='text']), .search-filters select").on("change", function() {
           if($(this).hasClass('proximity-range') && $("#proximityPostcode").val().trim() == "") {

--- a/web/app/themes/estyn/resources/views/partials/sectors-inside-full-width-arc-container.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/sectors-inside-full-width-arc-container.blade.php
@@ -1,0 +1,1 @@
+@include('components.list-inside-full-width-arc-container', ['heading' => __('Our education sectors', 'sage'), 'listItems' => $sectors, 'elemUniqueID' => $elemUniqueID])

--- a/web/app/themes/estyn/resources/views/sections/footer.blade.php
+++ b/web/app/themes/estyn/resources/views/sections/footer.blade.php
@@ -120,6 +120,12 @@
 					return;
 				}
 
+				function isMobile() {
+					return window.matchMedia('(max-width: 767px)').matches;
+				}
+
+				let providerSearchPageURL = "{{ \App\get_permalink_by_template('provider-search.blade.php') }}";
+
 				let searchBoxTypingTimer = setTimeout(function() {}, 0);
 				const searchBoxTypingInterval = 500;
 
@@ -157,9 +163,21 @@
 					}, processSearchBoxChangeInterval, $(this));
 				});
 
+				$('.estyn-search-box').on('focus', function() {
+					if(isMobile()) {
+						$(this).prev('.estyn-search-results-modal').modal('show');
+					}
+				});
+
 				$('.estyn-search-box-button').on('click', function() {
 					//console.log('click');
 					//$(this).prev('.estyn-search-results-modal').modal('show');
+
+					// If the search box is for providers, redirect to the provider search page (on desktop)
+					if( (!isMobile()) && $(this).hasClass('estyn-provider-search-button') ) {
+						window.location.href = providerSearchPageURL + '?search=' + $(this).prev('input').val();
+						return;
+					}
 
 					clearTimeout(processSearchBoxChangeTimer);
 					processSearchBoxChangeTimer = setTimeout(function($elem) {
@@ -198,9 +216,14 @@
 
 							//const $modal = $elem.prevAll('.estyn-search-results-modal:first');
 							// Use the element's data-bs-target attribute to find the modal
-							const $modal = $($elem.next('button').data('bs-target'));
+							let $modal = $($elem.next('button').data('bs-target'));
+
+							if(!$modal.length) {
+								// Assume the modal is a container of the search box
+								$modal = $elem.closest('.estyn-search-results-modal');
+							}
 							
-							console.log('Modal = ' + $elem.next('button').data('bs-target'))
+							console.log('Modal ID = ' + $modal.attr('id'));
 
 
 							const $modalUL = $modal.find('ul');

--- a/web/app/themes/estyn/resources/views/taxonomy-sector.blade.php
+++ b/web/app/themes/estyn/resources/views/taxonomy-sector.blade.php
@@ -41,7 +41,13 @@
         'introImageSrc' => $introImageSrc,
         'introImageAlt' => $introImageAlt,
         'introImageID' => $introImageID,
-        'cropIntroImagePortrait' => true
+        'cropIntroImagePortrait' => true,
+        'introLinks' => array_map(function($button) {
+            return [
+                'url' => $button['button_link_external'] ?: get_permalink($button['button_link'][0]->ID), // ACF Relationship field. Custom URL field has priority.
+                'text' => $button['button_label']
+            ];
+        }, get_field('intro_buttons', $term) ?: []), // ACF Repeater field
     ])
 
     <div class="container px-md-4 px-xl-5 mt-5 pt-4 pt-sm-5">
@@ -208,7 +214,17 @@
                     'doNotDoJavaScript' => false
                 ])--}}
                 
-                <div class="pb-5">
+
+                <div class="reportMain pt-md-5 pb-5">
+                    <div class="container px-md-4 px-xl-5 pb-md-5">
+                        @if(!empty($sectorLatestInspectionReports))
+                            @include('partials.inspection-and-report-schedule', [
+                                'inspectionReports' => $sectorLatestInspectionReports,
+                            ])
+                        @endif
+                    </div>
+                </div>
+                {{--<div class="pb-5">
                 @include('partials.cta', [
                     'ctaHeading' => __('Our education map of Wales', 'sage'),
                     'ctaText' => __('Find providers across Wales using our handy map', 'sage'),
@@ -221,16 +237,7 @@
                     'showSearchBox' => true,
                     'ctaContainerExtraClasses' => 'ctaSearchMapContainer'
                 ])
-                </div>
-                <div class="reportMain pt-md-5 pb-5">
-                    <div class="container px-md-4 px-xl-5 pb-md-5">
-                        @if(!empty($sectorLatestInspectionReports))
-                            @include('partials.inspection-and-report-schedule', [
-                                'inspectionReports' => $sectorLatestInspectionReports,
-                            ])
-                        @endif
-                    </div>
-                </div>
+                </div>--}}
             </div>
         </div>
     </div>

--- a/web/app/themes/estyn/resources/views/template-home.blade.php
+++ b/web/app/themes/estyn/resources/views/template-home.blade.php
@@ -219,7 +219,7 @@
 </div>
 --}}
 <div id="home-map-search-section" class="pt-md-5">
-  @include('partials.cta', [
+  {{--@include('partials.cta', [
     'ctaHeading' => __('Our education map of Wales', 'sage'),
     'ctaText' => __('Find providers across Wales using our handy map', 'sage'),
     'ctaButtonLinkURL' => App\get_permalink_by_template('provider-search.blade.php'),
@@ -231,7 +231,8 @@
     'showSearchBox' => true,
     'darkArc' => true,
     'ctaContainerExtraClasses' => 'ctaSearchMapContainer'
-  ])
+  ])--}}
+  @include('partials.sectors-inside-full-width-arc-container')
 </div>
 
   <div class="pt-md-5 mt-5 pb-md-5">

--- a/web/app/themes/estyn/resources/views/template-home.blade.php
+++ b/web/app/themes/estyn/resources/views/template-home.blade.php
@@ -55,13 +55,14 @@
                       <div class="modal-dialog modal-fullscreen">
                         <div class="modal-content">
                           <div class="modal-header">
-                            <h5 class="modal-title">{{ __('Search results', 'sage') }}</h5>
+                            {{--<h5 class="modal-title">{{ __('Search results', 'sage') }}</h5>--}}
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close', 'sage') }}"></button>
                           </div>
                           <div class="modal-body">
                             <div class="row">
                               <div class="col">
-                                <div class="estyn-search-container input-group mb-3">
+                                <h3 class="mb-3">{{ __('Find a provider', 'sage') }}</h3>
+                                <div class="estyn-search-container input-group mb-4">
                                   <input type="text" list="home-provider-search-mobile-datalist-options" class="estyn-search-box form-control" data-posttype="estyn_eduprovider" placeholder="" aria-label="providerSearch" aria-describedby="providerSearch">
                                   <button class="estyn-search-box-button estyn-provider-search-button btn btn-secondary" type="button" id="homeMobileProviderSearch"><i class="fa-sharp fa-solid fa-magnifying-glass"></i></button>
                                   <datalist class="search-datalist" id="home-provider-search-mobile-datalist-options">

--- a/web/app/themes/estyn/resources/views/template-home.blade.php
+++ b/web/app/themes/estyn/resources/views/template-home.blade.php
@@ -52,13 +52,24 @@
                   <label for="providerSearch" class="form-label mb-2 mb-md-4">{{ get_field('provider_search_description') }}</label>
                   <div class="estyn-search-container input-group mb-3">
                     <div class="modal estyn-search-results-modal" tabindex="-1" id="home-hero-provider-search-modal">
-                      <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-dialog modal-fullscreen">
                         <div class="modal-content">
                           <div class="modal-header">
                             <h5 class="modal-title">{{ __('Search results', 'sage') }}</h5>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close', 'sage') }}"></button>
                           </div>
                           <div class="modal-body">
+                            <div class="row">
+                              <div class="col">
+                                <div class="estyn-search-container input-group mb-3">
+                                  <input type="text" list="home-provider-search-mobile-datalist-options" class="estyn-search-box form-control" data-posttype="estyn_eduprovider" placeholder="" aria-label="providerSearch" aria-describedby="providerSearch">
+                                  <button class="estyn-search-box-button estyn-provider-search-button btn btn-secondary" type="button" id="homeMobileProviderSearch"><i class="fa-sharp fa-solid fa-magnifying-glass"></i></button>
+                                  <datalist class="search-datalist" id="home-provider-search-mobile-datalist-options">
+
+                                  </datalist>
+                                </div>
+                              </div>
+                            </div>
                             <div class="row">
                               <div class="col">
                                 <ul class="estyn-search-results-list list-group list-group-flush">
@@ -71,7 +82,7 @@
                       </div>
                     </div>
                     <input type="text" list="home-provider-search-datalist-options" class="estyn-search-box form-control" data-posttype="estyn_eduprovider" placeholder="" aria-label="providerSearch" aria-describedby="providerSearch">
-                    <button class="estyn-search-box-button btn btn-secondary" data-bs-toggle="modal" data-bs-target="#home-hero-provider-search-modal" type="button" id="providerSearch"><i class="fa-sharp fa-solid fa-magnifying-glass"></i></button>
+                    <button class="estyn-search-box-button estyn-provider-search-button btn btn-secondary" data-bs-toggle="modal" data-bs-target="#home-hero-provider-search-modal" type="button" id="providerSearch"><i class="fa-sharp fa-solid fa-magnifying-glass"></i></button>
                     <datalist class="search-datalist" id="home-provider-search-datalist-options">
 
                     </datalist>

--- a/web/app/themes/estyn/resources/views/template-home.blade.php
+++ b/web/app/themes/estyn/resources/views/template-home.blade.php
@@ -276,6 +276,11 @@
         'doNotDoJavaScript' => false
       ])
     </div>
+    @if(!empty($homeData['faqs']))
+    <div class="pb-md-5">
+      @include('partials.home-faqs', ['faqs' => $homeData['faqs']])
+    </div>
+    @endif
   </div>
 
   @while(have_posts()) @php(the_post())


### PR DESCRIPTION
Home page hero provider search:

- Styling fixes
- Clicking the button, on desktop, takes you to the provider search page with the search term.
- Clicking/tapping on the search box or button brings up the modal, on mobile, which now contains its own search box and button, and is styled as per the design

New 'sectors' section added to home page, replacing the 'map CTA'.
- Coded as a component so could be reused in future, turned into a block etc.

Accordion/FAQs block improved - full width + blue background, and you can add a heading to it now.

Search page filters improvements:

- Tags section is scrollable and searchable as per new design
- Proximity filter changed to select box as per new design
- Year - changed to select boxes as per new design
- Reset button added (will be changed if new design provided)

Sectors - wherever there's a list of them, they are ordered by 'count' which means the most popular come first.

Sector landing page - You can now add buttons to the hero intro.

Checkboxes styled like the data tool ones.

Note: Some new code exists which adds the FAQs section to the home page, but is unused. Keeping it in just incase we need it.