### PR TITLE
Jonoshea dev

### DIFF
--- a/web/app/themes/estyn/app/View/Composers/AboutComposer.php
+++ b/web/app/themes/estyn/app/View/Composers/AboutComposer.php
@@ -23,12 +23,17 @@ class AboutComposer extends Composer
          * Get all 'estyn_team_member' posts, along with their
          * associated 'team_member_category' terms (max 1 each)
          */
-        $teamMembers = get_posts([
+        $teamMembersEn = get_posts([
             'post_type' => 'estyn_team_member',
             'posts_per_page' => -1,
             'orderby' => 'menu_order',
             'order' => 'ASC',
         ]);
+
+        $teamMembers = [];
+        foreach($teamMembersEn as $teamMemberEn) {
+            $teamMembers[] = get_post(pll_get_post($teamMemberEn->ID));
+        }
 
         // Add the 'team_member_category' term to each team member post object
         $teamMembers = array_map(function($teamMember) {

--- a/web/app/themes/estyn/app/View/Composers/EventsComposer.php
+++ b/web/app/themes/estyn/app/View/Composers/EventsComposer.php
@@ -31,15 +31,32 @@ class EventsComposer extends Composer
 
         $items = [];
 
+        $current_language = pll_current_language();
+        $locale = $current_language == 'cy' ? 'cy_GB' : get_locale();
+
+        $formatter = new \IntlDateFormatter(
+            $locale,
+            \IntlDateFormatter::LONG,
+            \IntlDateFormatter::NONE,
+            date_default_timezone_get(),
+            \IntlDateFormatter::GREGORIAN,
+            'd MMMM yyyy' // Adjust the date format as needed
+        );
+
         foreach($events as $event) {
             // If the date has passed, skip this event
             if(strtotime(get_field('event_date', $event)) < time()) {
                 continue;
             }
 
+            $timestamp = strtotime(get_field('event_date', $event));
+            $formatted_date = $formatter->format($timestamp);        
+
             $args = [
                 'title' => get_the_title($event),
                 'date' => get_field('event_date', $event),
+                'formatted_date' => $formatted_date,
+                'timestamp' => $timestamp,
                 'link' => empty(get_field('event_external_link', $event)) ? get_permalink($event) : get_field('event_external_link', $event),
                 'featured_image_src' => get_the_post_thumbnail_url($event, 'full'),
                 'featured_image_alt' => get_post_meta(get_post_thumbnail_id($event), '_wp_attachment_image_alt', true),

--- a/web/app/themes/estyn/app/setup.php
+++ b/web/app/themes/estyn/app/setup.php
@@ -2159,6 +2159,48 @@ if (defined('WP_CLI') && WP_CLI) {
     }
 
     \WP_CLI::add_command('generate_welsh_providers', __NAMESPACE__ . '\\Welsh_Providers_Command');
+
+
+
+    // Remove '-cy' suffix from the URL slug of all 'estyn_eduprovider' posts
+    class Remove_Cy_Suffix_Command {
+        /**
+         * Removes '-cy' suffix from the URL slug of all 'estyn_eduprovider' posts.
+         *
+         * ## EXAMPLES
+         *
+         *     wp remove_cy_suffix
+         *
+         */
+        public function __invoke($args, $assoc_args) {
+            $args = array(
+                'post_type' => 'estyn_eduprovider',
+                'posts_per_page' => -1, // Retrieve all posts
+                'post_status' => 'publish', // Only get published posts
+            );
+    
+            $posts = get_posts($args);
+    
+            foreach ($posts as $post) {
+                $slug = $post->post_name;
+                // Check if slug ends with '-cy'
+                if (substr($slug, -3) === '-cy') {
+                    // Remove '-cy' from the end
+                    $new_slug = substr($slug, 0, -3);
+                    // Update the post slug
+                    wp_update_post(array(
+                        'ID' => $post->ID,
+                        'post_name' => $new_slug, // Update the slug
+                    ));
+                    error_log('Updated slug for post ' . $post->ID . ' to ' . $new_slug);
+                }
+            }
+    
+            \WP_CLI::success('Removed "-cy" suffix from the URL slug of all "estyn_eduprovider" posts.');
+        }
+    }
+    
+    \WP_CLI::add_command('remove_cy_suffix', __NAMESPACE__ . '\\Remove_Cy_Suffix_Command');
 }
 
 // Make sure you only run this once! (use the WP CLI command, i.e. wp generate_welsh_providers, from the project root directly)

--- a/web/app/themes/estyn/app/setup.php
+++ b/web/app/themes/estyn/app/setup.php
@@ -2292,3 +2292,30 @@ function generateWelshProviders() {
         error_log($errorString);
     }
 }
+
+// Useful for making sure dates are formatted correctly in the correct language
+function estynIntlDateFormatter($format = 'd MMMM yyyy') {
+    $current_language = pll_current_language();
+    $locale = $current_language == 'cy' ? 'cy_GB' : get_locale();
+
+    return new \IntlDateFormatter(
+        $locale,
+        \IntlDateFormatter::LONG,
+        \IntlDateFormatter::NONE,
+        date_default_timezone_get(),
+        \IntlDateFormatter::GREGORIAN,
+        $format
+    );
+}
+
+function estynFormatDate($dateString, $outputFormat = 'd MMMM yyyy') {
+    try {
+        $date = new \DateTime($dateString);
+    } catch(\Exception $e) {
+        return $dateString;
+    }
+    
+    $formatter = estynIntlDateFormatter($outputFormat);
+
+    return $formatter->format($date);
+}

--- a/web/app/themes/estyn/resources/views/partials/content-single-estyn_imp_resource.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/content-single-estyn_imp_resource.blade.php
@@ -188,7 +188,7 @@
                         } else {
                           // Get the provider post objects
                           $featuredProviders = array_map(function($providerID) {
-                            return get_post($providerID);
+                            return get_post(pll_get_post($providerID));
                           }, $featuredProviders);
                         }
                     }

--- a/web/app/themes/estyn/resources/views/partials/search-page.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/search-page.blade.php
@@ -13,7 +13,7 @@
   - Type (news/blog)(News Articles is a CPT, blog posts are Posts)
   - Dates (year)
   - [Tags? (blog posts only)]
-  - Sort: Publication date, title, type
+  - Sort: Latest updated, Publication date, title, type
 
   Inspection reports:
   - Sector
@@ -898,13 +898,13 @@
                 @if(empty($isProviderSearch) && empty($isInspectionScheduleSearch))
                   <label class="text-nowrap me-3" for="sort-by">{{ __('Sort by', 'sage') }}</label>
                   <select id="sort-by" class="form-select">
-                    @if((!isset($isNewsAndBlog) || !$isNewsAndBlog) && (!isset($isProviderSearch) || !$isProviderSearch) && (!isset($isInspectionScheduleSearch) || !$isInspectionScheduleSearch) && !(isset($isInspectionReportsSearch)) )
+{{--                     @if((!isset($isNewsAndBlog) || !$isNewsAndBlog) && (!isset($isProviderSearch) || !$isProviderSearch) && (!isset($isInspectionScheduleSearch) || !$isInspectionScheduleSearch) && !(isset($isInspectionReportsSearch)) )
                       <option value="lastUpdated">{{ __('Latest updated', 'sage') }}</option>
-                    @endif
+                    @endif --}}
                     @if(!isset($isProviderSearch) || !$isProviderSearch)
                       <option value="date">{{ __('Publication date', 'sage') }}</option>
                     @endif
-                    @if(isset($isInspectionReportsSearch) && $isInspectionReportsSearch)
+                    @if( !empty($isImprovementResourcesSearch) || !empty($isInspectionReportsSearch) || !empty($isNewsAndBlog)  )
                       <option value="lastUpdated">{{ __('Latest updated', 'sage') }}</option>
                     @endif
                     <option value="title">{{ __('Title', 'sage') }}</option>

--- a/web/app/themes/estyn/resources/views/partials/slider.blade.php
+++ b/web/app/themes/estyn/resources/views/partials/slider.blade.php
@@ -88,8 +88,8 @@
                             <img class="img-fluid" src="{{ $carouselItem['featured_image_src'] }}" alt="{{ $carouselItem['featured_image_alt'] ?? '' }}" />
                         </div>
                         <div class="card-footer py-sm-4 pb-0 px-0">
-                            @if(!empty($carouselItem['date']))
-                                <p class="slider-item-date mb-0">{{ (new \DateTime($carouselItem['date']))->format('j F Y') }}</p>
+                            @if( (!empty($carouselItem['date'])) || (!empty($carouselItem['formatted_date'])) )
+                                <p class="slider-item-date mb-0">{{ empty($carouselItem['formatted_date']) ? ((\App\estynFormatDate($carouselItem['date']))) : $carouselItem['formatted_date'] }}</p>
                             @endif
                             @if(!empty($carouselItem['link']))
                             <a class="stretched-link" href="{{ $carouselItem['link'] ?? '#' }}"><h4 class="mb-0 {{ !empty($carouselItem['excerpt']) ? 'mb-2' : '' }}">{{ html_entity_decode($carouselItem['title'], ENT_QUOTES, 'UTF-8') }}</h4></a>


### PR DESCRIPTION
See commits.

Will also do the following on Dev:

1. Run "wp remove_cy_suffix" and "wp sync_post_dates" to remove "-cy" from the URL slugs of the Welsh versions of Providers, and correct the publication dates of the Welsh versions of news and blog posts.
2. Hide entity id (old db) from news articles acf (acf-field-disabled)
3. Export and import News Article and Blog Post Details ACF field groups due to ‘last updated’ added
4. Update import templates for news articles (eng and wel) and run import to insert the ‘last updated’ date.
